### PR TITLE
Update target-group-register-targets.md

### DIFF
--- a/doc_source/target-group-register-targets.md
+++ b/doc_source/target-group-register-targets.md
@@ -18,7 +18,7 @@ When you register EC2 instances as targets, you must ensure that the security gr
 
 + Network Load Balancers do not have associated security groups\. Therefore, the security groups for your targets must use IP addresses to allow traffic from the load balancer\.
 
-+ You cannot allow traffic from clients to targets through the load balancer using the security groups for the clients in the security groups for the targets\.
++ Security groups associated with targets must reference client IP addresses and/or CIDR blocks in their ingress rules \- references to client security groups \("sg-xxxxxx"\) are not supported for traffic through the load balancer\.
 
 
 **Recommended Rules**  


### PR DESCRIPTION
Updated the limits text to make it clearer that target security groups cannot reference client security groups in their ingress rules, only IP addresses and/or CIDR blocks.

*Issue #, if available:*

*Description of changes:*
Updated the limits text to make it clearer that target security groups cannot reference client security groups in their ingress rules, only IP addresses and/or CIDR blocks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
