### PR TITLE
Update load-balancer-target-groups.md

### DIFF
--- a/doc_source/load-balancer-target-groups.md
+++ b/doc_source/load-balancer-target-groups.md
@@ -32,10 +32,10 @@ When you create a target group, you specify its target type, which determines ho
 The following are the possible target types:
 
 `instance`  
-The targets are specified by instance ID\.
+The targets are specified by instance ID\, and the source is the client IP address and port\.
 
 `ip`  
-The targets are specified by IP address\.
+The targets are specified by IP address\, and the source is the private IP addresses of the load balancer nodes\.
 
 When the target type is `ip`, you can specify IP addresses from one of the following CIDR blocks:
 + The subnets of the VPC for the target group
@@ -51,7 +51,7 @@ You can't specify publicly routable IP addresses\.
 
 If you specify targets using an instance ID, traffic is routed to instances using the primary private IP address specified in the primary network interface for the instance\. If you specify targets using IP addresses, you can route traffic to an instance using any private IP address from one or more network interfaces\. This enables multiple applications on an instance to use the same port\. Note that each network interface can have its own security group\.
 
-If you specify targets using an instance ID, the source IP addresses of the clients are preserved and provided to your applications\. If you specify targets by IP address, the source IP addresses are the private IP addresses of the load balancer nodes\.
+If you specify targets using an instance ID, the source IP addresses of the clients are preserved and provided to your applications\. If you specify targets by IP address, the source IP addresses are the private IP addresses of the load balancer nodes,\ allowing multiple applications on the same instance to communicate with each other using the load balancer\.
 
 ## Registered Targets<a name="registered-targets"></a>
 

--- a/doc_source/load-balancer-target-groups.md
+++ b/doc_source/load-balancer-target-groups.md
@@ -32,10 +32,10 @@ When you create a target group, you specify its target type, which determines ho
 The following are the possible target types:
 
 `instance`  
-The targets are specified by instance ID\, and the source is the client IP address and port\.
+The targets are specified by instance ID\.
 
 `ip`  
-The targets are specified by IP address\, and the source is the private IP addresses of the load balancer nodes\.
+The targets are specified by IP address\.
 
 When the target type is `ip`, you can specify IP addresses from one of the following CIDR blocks:
 + The subnets of the VPC for the target group
@@ -51,7 +51,9 @@ You can't specify publicly routable IP addresses\.
 
 If you specify targets using an instance ID, traffic is routed to instances using the primary private IP address specified in the primary network interface for the instance\. If you specify targets using IP addresses, you can route traffic to an instance using any private IP address from one or more network interfaces\. This enables multiple applications on an instance to use the same port\. Note that each network interface can have its own security group\.
 
-If you specify targets using an instance ID, the source IP addresses of the clients are preserved and provided to your applications\. If you specify targets by IP address, the source IP addresses are the private IP addresses of the load balancer nodes,\ allowing multiple applications on the same instance to communicate with each other using the load balancer\.
+If you specify targets using an instance ID, the source IP addresses of the clients are preserved and provided to your applications\. If you specify targets by IP address, the source IP addresses are the private IP addresses of the load balancer nodes\.
+
+If you have micro services on instances registered with a Network Load Balancer, you cannot use the load balancer to provide communication between them unless the load balancer is internet-facing or the instances are registered by IP address.
 
 ## Registered Targets<a name="registered-targets"></a>
 


### PR DESCRIPTION
Updated to clarify source address preservation.

The wording would benefit from further explanation around issues occurring where an NLB is used for multiple applications to communicate between each other while running on the same instance - this is a common occurence with ECS/EKS/Fargate etc.

Using a target type of 'ip' here is the solution to disable source preservation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
