### PR TITLE
Fix example S3 Bucket Policy for allowing NLB to write logs to S3

### DIFF
--- a/doc_source/load-balancer-access-logs.md
+++ b/doc_source/load-balancer-access-logs.md
@@ -110,7 +110,7 @@ When you enable access logging, you must specify an S3 bucket for the access log
           "Service": [ "delivery.logs.amazonaws.com" ]
         },
         "Action": [ "s3:GetBucketAcl" ],
-        "Resource": "arn:aws:s3:::bucket_name*",
+        "Resource": "arn:aws:s3:::bucket_name"
       }
     ]
   }


### PR DESCRIPTION
*Description of changes:*

Hi,

I was following along with your example S3 bucket policy for NLB logging and hit an error because:

1) The stray `,` at the end of the statement makes in invalid JSON
2) The resource for `GetBucketAcl` needs to be the bucket name without the wildcard.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
