### PR TITLE
Update the bucket policy with required permissions

### DIFF
--- a/doc_source/load-balancer-access-logs.md
+++ b/doc_source/load-balancer-access-logs.md
@@ -111,6 +111,20 @@ When you enable access logging, you must specify an S3 bucket for the access log
         },
         "Action": [ "s3:GetBucketAcl" ],
         "Resource": "arn:aws:s3:::bucket_name"
+      },
+      {
+        "Sid": "AWSLogDeliveryWrite",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": [ "delivery.logs.amazonaws.com" ]
+        },
+        "Action": [ "s3:PutObject" ],
+        "Resource": "arn:aws:s3:::bucket_name",
+        "Condition": {
+          "StringEquals": {
+            "s3:x-amz-acl": "bucket-owner-full-control"
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
Bucket policy must allow S3:PutObject to the service delivery.logs.amazonaws.com, otherwise it will fail.

*Issue #, if available:*
Following the current policy, enabling logs would fail

*Description of changes:*
Added the AWSLogDeliveryWrite statement to the bucket policy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
