### PR TITLE
Update create-tls-listener.md

### DIFF
--- a/doc_source/create-tls-listener.md
+++ b/doc_source/create-tls-listener.md
@@ -4,7 +4,7 @@ You must specify exactly one server certificate per TLS listener\. The load bala
 
 Elastic Load Balancing uses a TLS negotiation configuration, known as a security policy, to negotiate TLS connections between a client and the load balancer\. A security policy is a combination of protocols and ciphers\. The protocol establishes a secure connection between a client and a server and ensures that all data passed between the client and your load balancer is private\. A cipher is an encryption algorithm that uses encryption keys to create a coded message\. Protocols use several ciphers to encrypt data over the internet\. During the connection negotiation process, the client and the load balancer present a list of ciphers and protocols that they each support, in order of preference\. The first cipher on the server's list that matches any one of the client's ciphers is selected for the secure connection\.
 
-Network Load Balancers do not support TLS renegotiation or TLS session resumption for client or target connections\.
+While Network Load Balancers do support back-end server encryption to your targets, they do not support TLS renegotiation or TLS session resumption for client or target connections\.
 
 ## Server Certificates<a name="tls-listener-certificates"></a>
 

--- a/doc_source/create-tls-listener.md
+++ b/doc_source/create-tls-listener.md
@@ -4,8 +4,6 @@ You must specify exactly one server certificate per TLS listener\. The load bala
 
 Elastic Load Balancing uses a TLS negotiation configuration, known as a security policy, to negotiate TLS connections between a client and the load balancer\. A security policy is a combination of protocols and ciphers\. The protocol establishes a secure connection between a client and a server and ensures that all data passed between the client and your load balancer is private\. A cipher is an encryption algorithm that uses encryption keys to create a coded message\. Protocols use several ciphers to encrypt data over the internet\. During the connection negotiation process, the client and the load balancer present a list of ciphers and protocols that they each support, in order of preference\. The first cipher on the server's list that matches any one of the client's ciphers is selected for the secure connection\.
 
-While Network Load Balancers do support back-end server encryption to your targets, they do not support TLS renegotiation or TLS session resumption for client or target connections\.
-
 ## Server Certificates<a name="tls-listener-certificates"></a>
 
 The load balancer uses an X\.509 certificate \(server certificate\)\. Certificates are a digital form of identification issued by a certificate authority \(CA\)\. A certificate contains identification information, a validity period, a public key, a serial number, and the digital signature of the issuer\.


### PR DESCRIPTION
*Description of changes:*
Clarified that NLBs support back-end encryption, because sometimes "renegotiation" is used in the incorrect context to mean that a LB terminates TLS and then re-encrypts (starts a new TLS session) to targets.  However, the context of "renegotiation" means something else in the TLS protocol.  Some readers could be confused, so hoping this pull request can clarify the distinction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
