### PR TITLE
Clarify use of TCP keep-alive packets

### DIFF
--- a/doc_source/network-load-balancers.md
+++ b/doc_source/network-load-balancers.md
@@ -108,6 +108,6 @@ Use the [modify\-load\-balancer\-attributes](https://docs.aws.amazon.com/cli/lat
 
 For each TCP request that a client makes through a Network Load Balancer, the state of that connection is tracked\. If no data is sent through the connection by either the client or target for longer than the idle timeout, the connection is closed\. If a client or a target sends data after the idle timeout period elapses, it receives a TCP RST packet to indicate that the connection is no longer valid\.
 
-Elastic Load Balancing sets the idle timeout value for TCP flows to 350 seconds\. You cannot modify this value\. For TCP listeners, clients and targets can use TCP keepalive packets to reset the idle timeout\. TCP keepalive packets are not supported for TLS listeners\.
+Elastic Load Balancing sets the idle timeout value for TCP flows to 350 seconds\. You cannot modify this value\. For TCP listeners, either clients or targets can use TCP keepalive packets to reset the idle timeout\. TCP keepalive packets are not supported for TLS listeners\.
 
 While UDP is connectionless, the load balancer maintains UDP flow state based on the source and destination IP addresses and ports, ensuring that packets that belong to the same flow are consistently sent to the same target\. After the idle timeout period elapses, the load balancer considers the incoming UDP packet as a new flow and routes it to a new target\. Elastic Load Balancing sets the idle timeout value for UDP flows to 120 seconds\.


### PR DESCRIPTION
Clarify that a TCP connection through the NLB can be kept alive beyond the 350-second idle timeout, either by the client _or_ target sending keep-alive probes, or both.

The current documentation could be interpreted to mean that both the client _and_ server need to send keep-alive probes to keep the connection alive, as if the client-to-NLB and NLB-to-target connections are entirely independent, and the NLB requiring both sides to be explicitly kept alive.

Example of confusion in the wild: https://www.reddit.com/r/aws/comments/d19054/nlb_slow_to_react_to_target_group_changes/ezkqb3g

(I see that the wording (and actual behaviour?) was updated in e347e595 to include both client and target. The reddit user having keep-alive problems was possibly trying this out before that fix.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
