### PR TITLE
Add note about target registration time

### DIFF
--- a/doc_source/target-group-health-checks.md
+++ b/doc_source/target-group-health-checks.md
@@ -1,5 +1,7 @@
 # Health Checks for Your Target Groups<a name="target-group-health-checks"></a>
 
+You register your targets with one or more target groups\. The load balancer starts routing requests to the target as soon as the registration process completes and the target passes the initial health checks\. It can take a few minutes for the registration process to complete and health checks to start\.
+
 Network Load Balancers use active and passive health checks to determine whether a target is available to handle requests\. By default, each load balancer node routes requests only to the healthy targets in its Availability Zone\. If you enable cross\-zone load balancing, each load balancer node routes requests to the healthy targets in all enabled Availability Zones\. For more information, see [Cross\-Zone Load Balancing](network-load-balancers.md#cross-zone-load-balancing)\.
 
 With active health checks, the load balancer periodically sends a request to each registered target to check its status\. Each load balancer node checks the health of each target, using the health check settings for the target group with which the target is registered\. After each health check is completed, the load balancer node closes the connection that was established for the health check\.
@@ -37,7 +39,7 @@ The following table describes the possible values for the health status of a reg
 
 | Value | Description | 
 | --- | --- | 
-| `initial` |  The load balancer is in the process of registering the target or performing the initial health checks on the target\. It may take a few minutes for health checks to start.  | 
+| `initial` |  The load balancer is in the process of registering the target or performing the initial health checks on the target\.  | 
 | `healthy` |  The target is healthy\.  | 
 | `unhealthy` |  The target did not respond to a health check or failed the health check\.  | 
 | `unused` |  The target is not registered with a target group, the target group is not used in a listener rule for the load balancer, or the target is in an Availability Zone that is not enabled for the load balancer\.  | 

--- a/doc_source/target-group-health-checks.md
+++ b/doc_source/target-group-health-checks.md
@@ -37,7 +37,7 @@ The following table describes the possible values for the health status of a reg
 
 | Value | Description | 
 | --- | --- | 
-| `initial` |  The load balancer is in the process of registering the target or performing the initial health checks on the target\.  | 
+| `initial` |  The load balancer is in the process of registering the target or performing the initial health checks on the target\. It may take a few minutes for health checks to start.  | 
 | `healthy` |  The target is healthy\.  | 
 | `unhealthy` |  The target did not respond to a health check or failed the health check\.  | 
 | `unused` |  The target is not registered with a target group, the target group is not used in a listener rule for the load balancer, or the target is in an Availability Zone that is not enabled for the load balancer\.  | 


### PR DESCRIPTION
Add note about target registration time, clarifying that it may take a few minutes before health checking actually starts.

There appears to be a significant delay between targets first entering the "initial" state, and the first health check being sent. The duration seems to be around 120 seconds. I chose to use "a few minutes" both to clarify that it may take a while, but also to not present any particular duration or guarantee.

I think it is useful to developers and users that there's at least some clarification here, as I would argue that it is confusing to see your newly launched target being up and ready to receive traffic (as confirmed by logs and direct testing of service ports), but still taking 120+ seconds to reach a healthy state.

It may be worth running this by the NLB dev team to clarify with them how this actually works.

Example of confusion in the wild: https://www.reddit.com/r/aws/comments/d19054/nlb_slow_to_react_to_target_group_changes/

This behaviour is at least confirmed using ECS Fargate with an NLB using IP-based target groups. I have not tried other combinations to see if the NLB behaves differently.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.