### PR TITLE
Update network-load-balancers.md

### DIFF
--- a/doc_source/network-load-balancers.md
+++ b/doc_source/network-load-balancers.md
@@ -4,7 +4,7 @@ A *load balancer* serves as the single point of contact for clients\. Clients se
 
 To configure your load balancer, you create [target groups](load-balancer-target-groups.md), and then register targets with your target groups\. Your load balancer is most effective if you ensure that each enabled Availability Zone has at least one registered target\. You also create [listeners](load-balancer-listeners.md) to check for connection requests from clients and route requests from clients to the targets in your target groups\.
 
-Network Load Balancers support connections from clients over VPC peering, AWS managed VPN, and third\-party VPN solutions\.
+Network Load Balancers support connections from clients over VPC peering, AWS managed VPN, AWS Direct Connect and third\-party VPN solutions\.
 
 **Topics**
 + [Load Balancer State](#load-balancer-state)


### PR DESCRIPTION
Added AWS Direct Connect in line #7 at the top. NLBs support access from on-prem via Direct Connect: https://aws.amazon.com/about-aws/whats-new/2018/09/network-load-balancer-now-supports-aws-vpn/ --> "Previously, access to Network Load Balancer from on-premises networks was only available over AWS Direct Connect..."

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
