### PR TITLE
Added note about IP preservation and PrivateLink

### DIFF
--- a/doc_source/load-balancer-target-groups.md
+++ b/doc_source/load-balancer-target-groups.md
@@ -84,6 +84,8 @@ If you specify targets by IP address, the source IP addresses depend on the prot
 
 If you have micro services on instances registered with a Network Load Balancer, you cannot use the load balancer to provide communication between them unless the load balancer is internet\-facing or the instances are registered by IP address\. For more information, see [Connections time out for requests from a target to its load balancer](load-balancer-troubleshooting.md#loopback-timeout)\.
 
+If you are using VPC Endpoint Services to provide your service to other consumers, the source IP addresses of the clients are not preserved and traffic to your applications appears to orinigate from the network load balancer\. For more information, see [VPC endpoint services (AWS PrivateLink)](https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-service.html#on-premises-connection)\.
+
 ## Registered targets<a name="registered-targets"></a>
 
 Your load balancer serves as a single point of contact for clients and distributes incoming traffic across its healthy registered targets\. Each target group must have at least one registered target in each Availability Zone that is enabled for the load balancer\. You can register each target with one or more target groups\. You can register each EC2 instance or IP address with the same target group multiple times using different ports, which enables the load balancer to route requests to microservices\.

--- a/doc_source/load-balancer-target-groups.md
+++ b/doc_source/load-balancer-target-groups.md
@@ -82,9 +82,9 @@ If you specify targets by IP address, the source IP addresses depend on the prot
 + TCP and TLS: The source IP addresses are the private IP addresses of the load balancer nodes\. If you need the IP addresses of the clients, enable [proxy protocol](#proxy-protocol) and get the client IP addresses from the proxy protocol header\.
 + UDP and TCP\_UDP: The source IP addresses are the private IP addresses of the clients\.
 
-If you have micro services on instances registered with a Network Load Balancer, you cannot use the load balancer to provide communication between them unless the load balancer is internet\-facing or the instances are registered by IP address\. For more information, see [Connections time out for requests from a target to its load balancer](load-balancer-troubleshooting.md#loopback-timeout)\.
+If you are using the Network Load Balancer with a VPC endpoint service, the source IP addresses provided to your application are the private IP addresses of the load balancer nodes\. If you need the IP addresses of the service consumers, enable [proxy protocol](#proxy-protocol) on the load balancer\.
 
-If you are using VPC Endpoint Services to provide your service to other consumers, the source IP addresses of the clients are not preserved and traffic to your applications appears to orinigate from the network load balancer\. For more information, see [VPC endpoint services (AWS PrivateLink)](https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-service.html#on-premises-connection)\.
+If you have micro services on instances registered with a Network Load Balancer, you cannot use the load balancer to provide communication between them unless the load balancer is internet\-facing or the instances are registered by IP address\. For more information, see [Connections time out for requests from a target to its load balancer](load-balancer-troubleshooting.md#loopback-timeout)\.
 
 ## Registered targets<a name="registered-targets"></a>
 


### PR DESCRIPTION
*Description of changes:*

When configuring AWS Service Endpoints with a Network Load Balancer, the source IP preservation functionality does not persist. This is present in the PrivateLink documentation, but I suggest a note should be present here to make this change in functionality clearer when using AWS PrivateLink. I have added this note, with a reference back to the AWS PrivateLink documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
