### PR TITLE
Update network-load-balancer-getting-started.md

### DIFF
--- a/doc_source/network-load-balancer-getting-started.md
+++ b/doc_source/network-load-balancer-getting-started.md
@@ -34,7 +34,7 @@ Create a target group, which is used in request routing\. The rule for your list
 
 1. For **Protocol**, choose **TCP**, and for **Port**, choose **80**\.
 
-1. For **VPC** select the VPC that contains your instances\. Keep **Protocol version** as **HTTP1**\.
+1. For **VPC** select the VPC that contains your instances\.
 
 1. For **Health checks**, keep the default settings\.
 


### PR DESCRIPTION
*Issue #, if available:*
when you choose TCP protocol (Step 1, point 6) there is no HTTP1 protocol version to keep (Step 1, point 7)
*Description of changes:*
removed "Keep Protocol version as HTTP1."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
